### PR TITLE
chore: align labeler with github-scrum label system

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,56 +1,43 @@
-# Configuration for labeler - https://github.com/actions/labeler
-"Type: Breaking change":
-  - head-branch:
-    - '^breaking/'
-    - '^breaking-'
+# Configuration for actions/labeler
+# Labels must match the github-scrum label system (namespaced prefixes).
 
-"Type: Feature":
+"type:feature":
   - head-branch:
-    - '^feat/'
-    - '^feat-'
-    - '^feature/'
-    - '^feature-'
+      - '^feat/'
+      - '^feature/'
+  - changed-files:
+      - any-glob-to-any-file:
+          - "github/resource_*.go"
+          - "github/data_source_*.go"
 
-"Type: Bug":
+"type:bug":
   - head-branch:
-    - '^fix/'
-    - '^fix-'
-    - '^bugfix/'
-    - '^bugfix-'
-    - '^bug/'
-    - '^bug-'
+      - '^fix/'
+      - '^bugfix/'
 
-"Deprecation":
+"type:chore":
   - head-branch:
-    - '^deprecate/'
-    - '^deprecate-'
-    - '^deprecation/'
-    - '^deprecation-'
+      - '^chore/'
+      - '^maint/'
+      - '^deps/'
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "GNUmakefile"
+          - ".goreleaser.yml"
+          - ".golangci.yml"
+          - ".gitignore"
+          - "go.mod"
+          - "go.sum"
 
-"Type: Maintenance":
+"type:docs":
   - head-branch:
-    - '^chore/'
-    - '^chore-'
-    - '^maintenance/'
-    - '^maintenance-'
-    - '^maint/'
-    - '^maint-'
-    - '^deps/'
-    - '^deps-'
-    - '^dependencies/'
-    - '^dependencies-'
-  # - changed-files:
-  #   - any-glob-to-any-file: 
-  #     - .github/workflows/**
-  #     - .github/labeler.yml
-  #     - .github/dependabot.yml
-  #     - .github/release.yml
+      - '^docs/'
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "website/**"
 
-"Type: Documentation":
+"type:spike":
   - head-branch:
-    - '^docs/'
-    - '^docs-'
-    - '^doc/'
-    - '^doc-'
-  # - changed-files:
-  #   - any-glob-to-any-file: 'website/**'
+      - '^spike/'


### PR DESCRIPTION
## Summary

Fixes `.github/labeler.yml` to use the namespaced github-scrum label system instead of the upstream labels.

## Changes

**Labels removed** (upstream, incompatible with github-scrum):
- `Type: Breaking change`
- `Type: Feature`
- `Type: Bug`
- `Deprecation`
- `Type: Maintenance`
- `Type: Documentation`

**Labels added** (github-scrum system):
- `type:feature`
- `type:bug`
- `type:chore`
- `type:docs`
- `type:spike`

**Rules improved:**
- Added `changed-files` rules alongside `head-branch` rules, adapted to the Go provider layout (`github/resource_*.go`, `github/data_source_*.go`, `website/**`, etc.)
- Removed deprecated `breaking/` branch prefix rule (handled by `release-drafter` autolabeler via conventional commits instead)