### PR TITLE
fix(enterprise-teams): replace "Github" with "GitHub" in page_title

### DIFF
--- a/website/docs/d/enterprise.html.markdown
+++ b/website/docs/d/enterprise.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "github"
-page_title: "Github: github_enterprise"
+page_title: "GitHub: github_enterprise"
 description: |-
   Get an enterprise.
 ---

--- a/website/docs/r/enterprise_organization.html.markdown
+++ b/website/docs/r/enterprise_organization.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "github"
-page_title: "Github: github_enterprise_organization"
+page_title: "GitHub: github_enterprise_organization"
 description: |-
   Create and manages a GitHub enterprise organization.
 ---


### PR DESCRIPTION
## Summary

- Fixes `page_title: "Github: ..."` → `page_title: "GitHub: ..."` in two docs files that were missed in previous passes
- `website/docs/d/enterprise.html.markdown`
- `website/docs/r/enterprise_organization.html.markdown`

Closes #22

## Notes

The 7 files listed in the issue body were already correct. This PR fixes the 2 remaining files in the `enterprise-teams` branch that still had the wrong capitalization.