### PR TITLE
fix(enterprise-teams): fix incomplete error handling in listAllEnterpriseTeamOrganizations callers

### DIFF
--- a/github/resource_github_enterprise_team_organizations.go
+++ b/github/resource_github_enterprise_team_organizations.go
@@ -77,10 +77,16 @@ func resourceGithubEnterpriseTeamOrganizationsCreate(ctx context.Context, d *sch
 		return diag.Errorf("enterprise team not found")
 	}
 
-	// Verify no organizations are already assigned (authoritative resource)
+	// Verify no organizations are already assigned (authoritative resource).
+	// A 404 here means the team has no assignments yet — treat as empty and proceed.
 	existing, err := listAllEnterpriseTeamOrganizations(ctx, client, enterpriseSlug, team.Slug)
 	if err != nil {
-		return diag.FromErr(err)
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusNotFound {
+			existing = nil
+		} else {
+			return diag.FromErr(err)
+		}
 	}
 	if len(existing) > 0 {
 		return diag.Errorf("%q already has organizations assigned; import first or remove manually", team.Slug)
@@ -122,6 +128,11 @@ func resourceGithubEnterpriseTeamOrganizationsRead(ctx context.Context, d *schem
 
 	orgs, err := listAllEnterpriseTeamOrganizations(ctx, client, enterpriseSlug, teamSlug)
 	if err != nil {
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
## Summary

Fixes the `errors.As` check that was ineffective because both branches returned the error identically.

**Changes in `resource_github_enterprise_team_organizations.go`:**

- **`Read`**: 404 → `d.SetId("") + return nil` so resources deleted out-of-band are cleanly removed from state
- **`Create`** (pre-existence check): 404 → treat as empty (`existing = nil`) and proceed, since a new team may not have any assignments yet
- **`Delete`**: already correct — no change

Closes #29

## Reviewer feedback

> The error handling logic in `listEnterpriseTeamOrganizations` appears incomplete. The code checks if the error is a `githubv3.ErrorResponse` but then returns the error in both branches of the conditional, making the type assertion check ineffective.

The `errors.As` check now branches differently in each caller, making the type assertion effective.