### PR TITLE
fix(enterprise-teams): fix grammar in resource Description fields

### DIFF
--- a/github/resource_github_enterprise_team.go
+++ b/github/resource_github_enterprise_team.go
@@ -18,7 +18,7 @@ import (
 
 func resourceGithubEnterpriseTeam() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Manages a GitHub enterprise team.",
+		Description:   "Creates and manages a GitHub enterprise team.",
 		CreateContext: resourceGithubEnterpriseTeamCreate,
 		ReadContext:   resourceGithubEnterpriseTeamRead,
 		UpdateContext: resourceGithubEnterpriseTeamUpdate,

--- a/github/resource_github_enterprise_team_membership.go
+++ b/github/resource_github_enterprise_team_membership.go
@@ -14,7 +14,7 @@ import (
 
 func resourceGithubEnterpriseTeamMembership() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Manages membership of a user in a GitHub enterprise team.",
+		Description:   "Creates and manages membership of a user in a GitHub enterprise team.",
 		CreateContext: resourceGithubEnterpriseTeamMembershipCreate,
 		ReadContext:   resourceGithubEnterpriseTeamMembershipRead,
 		DeleteContext: resourceGithubEnterpriseTeamMembershipDelete,

--- a/github/resource_github_enterprise_team_organizations.go
+++ b/github/resource_github_enterprise_team_organizations.go
@@ -14,7 +14,7 @@ import (
 
 func resourceGithubEnterpriseTeamOrganizations() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Manages organization assignments for a GitHub enterprise team.",
+		Description:   "Creates and manages organization assignments for a GitHub enterprise team.",
 		CreateContext: resourceGithubEnterpriseTeamOrganizationsCreate,
 		ReadContext:   resourceGithubEnterpriseTeamOrganizationsRead,
 		UpdateContext: resourceGithubEnterpriseTeamOrganizationsUpdate,


### PR DESCRIPTION
## Summary

Use `"Creates and manages..."` (third-person singular) in all three enterprise-teams resources, consistent with provider conventions and reviewer feedback on upstream PR [#3008](https://github.com/integrations/terraform-provider-github/pull/3008).

### Files changed

- `github/resource_github_enterprise_team.go`: `"Manages..."` → `"Creates and manages a GitHub enterprise team."`
- `github/resource_github_enterprise_team_membership.go`: `"Manages membership..."` → `"Creates and manages membership of a user in a GitHub enterprise team."`
- `github/resource_github_enterprise_team_organizations.go`: `"Manages organization assignments..."` → `"Creates and manages organization assignments for a GitHub enterprise team."`

Closes #23