### PR TITLE
fix(enterprise-teams): use read-only language in data source Descriptions

### DIFF
--- a/github/data_source_github_enterprise_team_organizations.go
+++ b/github/data_source_github_enterprise_team_organizations.go
@@ -11,7 +11,7 @@ import (
 
 func dataSourceGithubEnterpriseTeamOrganizations() *schema.Resource {
 	return &schema.Resource{
-		Description: "Lists organizations assigned to a GitHub enterprise team.",
+		Description: "Retrieves information about organizations assigned to a GitHub enterprise team.",
 		ReadContext: dataSourceGithubEnterpriseTeamOrganizationsRead,
 
 		Schema: map[string]*schema.Schema{

--- a/github/data_source_github_enterprise_teams.go
+++ b/github/data_source_github_enterprise_teams.go
@@ -20,7 +20,7 @@ const (
 
 func dataSourceGithubEnterpriseTeams() *schema.Resource {
 	return &schema.Resource{
-		Description: "Lists all GitHub enterprise teams in an enterprise.",
+		Description: "Retrieves information about all GitHub enterprise teams in an enterprise.",
 		ReadContext: dataSourceGithubEnterpriseTeamsRead,
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
## Summary

Replace `"Lists..."` with `"Retrieves information about..."` in two data sources that incorrectly used mutation-implying language:

- `data_source_github_enterprise_teams.go`: `"Lists all GitHub enterprise teams..."` → `"Retrieves information about all GitHub enterprise teams..."`
- `data_source_github_enterprise_team_organizations.go`: `"Lists organizations assigned..."` → `"Retrieves information about organizations assigned..."`

Data sources are read-only; their `Description` must use `"Gets/Retrieves information about..."`, not `"Manages"` or `"Lists"`. Consistent with provider conventions and reviewer feedback on upstream PR [#3008](https://github.com/integrations/terraform-provider-github/pull/3008).

Closes #24