### PR TITLE
fix(cost-centers): use third-person verb in data source descriptions

### DIFF
--- a/github/data_source_github_enterprise_cost_center.go
+++ b/github/data_source_github_enterprise_cost_center.go
@@ -9,7 +9,7 @@ import (
 
 func dataSourceGithubEnterpriseCostCenter() *schema.Resource {
 	return &schema.Resource{
-		Description: "Use this data source to retrieve information about a specific enterprise cost center.",
+		Description: "Retrieves information about a specific GitHub enterprise cost center.",
 		ReadContext: dataSourceGithubEnterpriseCostCenterRead,
 
 		Schema: map[string]*schema.Schema{

--- a/github/data_source_github_enterprise_cost_centers.go
+++ b/github/data_source_github_enterprise_cost_centers.go
@@ -11,7 +11,7 @@ import (
 
 func dataSourceGithubEnterpriseCostCenters() *schema.Resource {
 	return &schema.Resource{
-		Description: "Use this data source to retrieve a list of enterprise cost centers.",
+		Description: "Retrieves a list of GitHub enterprise cost centers.",
 		ReadContext: dataSourceGithubEnterpriseCostCentersRead,
 
 		Schema: map[string]*schema.Schema{

--- a/website/docs/d/enterprise_cost_center.html.markdown
+++ b/website/docs/d/enterprise_cost_center.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 # github_enterprise_cost_center
 
-Use this data source to retrieve a GitHub enterprise cost center by ID.
+Retrieves information about a specific GitHub enterprise cost center.
 
 ## Example Usage
 

--- a/website/docs/d/enterprise_cost_centers.html.markdown
+++ b/website/docs/d/enterprise_cost_centers.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 # github_enterprise_cost_centers
 
-Use this data source to list GitHub enterprise cost centers.
+Retrieves a list of GitHub enterprise cost centers.
 
 ## Example Usage
 


### PR DESCRIPTION
## Summary

- Closes #51

## Changes

Updated `Description` field in both cost-center data sources and their corresponding docs to follow the AGENTS.md convention (third-person singular verb for data sources).

| File | Before | After |
|------|--------|-------|
| `data_source_github_enterprise_cost_center.go` | "Use this data source to retrieve..." | "Retrieves information about a specific GitHub enterprise cost center." |
| `data_source_github_enterprise_cost_centers.go` | "Use this data source to retrieve..." | "Retrieves a list of GitHub enterprise cost centers." |
| `website/docs/d/enterprise_cost_center.html.markdown` | "Use this data source to retrieve..." | "Retrieves information about a specific GitHub enterprise cost center." |
| `website/docs/d/enterprise_cost_centers.html.markdown` | "Use this data source to list..." | "Retrieves a list of GitHub enterprise cost centers." |