### PR TITLE
fix(scim): use buildTwoPartID for data source IDs

### DIFF
--- a/github/data_source_github_enterprise_scim_group.go
+++ b/github/data_source_github_enterprise_scim_group.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -39,7 +38,7 @@ func dataSourceGithubEnterpriseSCIMGroupRead(ctx context.Context, d *schema.Reso
 		return diag.FromErr(err)
 	}
 
-	d.SetId(fmt.Sprintf("%s/%s", enterprise, scimGroupID))
+	d.SetId(buildTwoPartID(enterprise, scimGroupID))
 
 	if err := d.Set("schemas", group.Schemas); err != nil {
 		return diag.FromErr(err)

--- a/github/data_source_github_enterprise_scim_user.go
+++ b/github/data_source_github_enterprise_scim_user.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -39,7 +38,7 @@ func dataSourceGithubEnterpriseSCIMUserRead(ctx context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 
-	d.SetId(fmt.Sprintf("%s/%s", enterprise, scimUserID))
+	d.SetId(buildTwoPartID(enterprise, scimUserID))
 
 	if err := d.Set("schemas", user.Schemas); err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
## Summary

Closes #53

Replace `fmt.Sprintf("%s/%s", ...)` with `buildTwoPartID()` in both SCIM data sources, consistent with the project convention defined in AGENTS.md.

## Changes

| File | Before | After |
|------|--------|-------|
| `data_source_github_enterprise_scim_user.go` | `fmt.Sprintf("%s/%s", enterprise, scimUserID)` | `buildTwoPartID(enterprise, scimUserID)` |
| `data_source_github_enterprise_scim_group.go` | `fmt.Sprintf("%s/%s", enterprise, scimGroupID)` | `buildTwoPartID(enterprise, scimGroupID)` |

Unused `"fmt"` import removed from both files.

## Note

Separator changes from `/` to `:`. As these are data sources (no persistent state for the ID), the risk of state breakage is low.