### PR TITLE
refactor(scim): move enterpriseSCIMMetaSchema() to util_enterprise_scim.go

### DIFF
--- a/github/data_source_github_enterprise_scim_groups.go
+++ b/github/data_source_github_enterprise_scim_groups.go
@@ -120,31 +120,6 @@ func dataSourceGithubEnterpriseSCIMGroupsRead(ctx context.Context, d *schema.Res
 	return nil
 }
 
-func enterpriseSCIMMetaSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"resource_type": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "The SCIM resource type.",
-		},
-		"created": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "The creation timestamp.",
-		},
-		"last_modified": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "The lastModified timestamp.",
-		},
-		"location": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "The resource location.",
-		},
-	}
-}
-
 func enterpriseSCIMGroupSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"schemas": {

--- a/github/util_enterprise_scim.go
+++ b/github/util_enterprise_scim.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	gh "github.com/google/go-github/v84/github"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // enterpriseSCIMListAllGroups fetches all SCIM groups for an enterprise with automatic pagination.
@@ -221,4 +222,29 @@ func flattenEnterpriseSCIMUser(user *gh.SCIMEnterpriseUserAttributes) map[string
 		m["id"] = *user.ID
 	}
 	return m
+}
+
+func enterpriseSCIMMetaSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"resource_type": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The SCIM resource type.",
+		},
+		"created": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The creation timestamp.",
+		},
+		"last_modified": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The lastModified timestamp.",
+		},
+		"location": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The resource location.",
+		},
+	}
 }


### PR DESCRIPTION
## Summary

Closes #54

Pure refactor — no functional change.

`enterpriseSCIMMetaSchema()` was defined in `data_source_github_enterprise_scim_groups.go` but referenced by both the groups and users data sources. Moving it to `util_enterprise_scim.go` (which already houses shared pagination and flatten utilities for this feature) makes the codebase easier to navigate.

## Changes

| File | Change |
|------|--------|
| `github/util_enterprise_scim.go` | Added `enterpriseSCIMMetaSchema()` + `schema` import |
| `github/data_source_github_enterprise_scim_groups.go` | Removed `enterpriseSCIMMetaSchema()` |

## Verification

`go build ./github/...` passes cleanly.